### PR TITLE
multi関数の実装

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,16 @@ function add(numbers) {
     }
     return result;
 }
+
+function multi(numbers) {
+    let result = 1;
+    for (let num of numbers){
+        result = result * num;
+    }
+    return result;
+}
+
 module.exports = {
-    add: add
+    add: add,
+    multi: multi
 };


### PR DESCRIPTION
練習用ですので、マージ不要
sumパッケージにmulti関数を追加したので、パッケージをインストールしたときにmultiどこ行ったと混乱しました。
「sumの中にaddとmultiがある」と気づくまでインストールできないと勘違い。
