### PR TITLE
パッケージにmulti関数を追加

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,14 @@ function add(numbers) {
     }
     return result;
 }
+function multi(numbers) {
+    let result = 1;
+    for (let num of numbers) {
+        result = result * num;
+    }
+    return result;
+}
 module.exports = {
-    add: add
+    add: add,
+    multi: multi
 };


### PR DESCRIPTION
マージ不要です。
１回目の修正で　掛け算だからマルチ関数側の初期値を1にするのを忘れていて　
0が返ってきたので　罠に引っかかりましたねー。
手直しして２回目のインストールでOKです。
